### PR TITLE
add routes api with sanctum

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -6,11 +6,12 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Laravel\Sanctum\HasApiTokens;
 
 class User extends Authenticatable
 {
     /** @use HasFactory<\Database\Factories\UserFactory> */
-    use HasFactory, Notifiable;
+    use HasApiTokens, HasFactory, Notifiable;
 
     /**
      * The attributes that are mass assignable.

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -3,19 +3,23 @@
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
-use Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
         $middleware->group('api', [
-            EnsureFrontendRequestsAreStateful::class,
             \Illuminate\Routing\Middleware\ThrottleRequests::class.':api',
-            \Illuminate\Auth\Middleware\Authenticate::class,
+            \Illuminate\Routing\Middleware\SubstituteBindings::class,
+        ]);
+
+        $middleware->alias([
+            'auth' => \Illuminate\Auth\Middleware\Authenticate::class,
+            'auth:sanctum' => \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {

--- a/database/migrations/2025_06_17_165107_create_personal_access_tokens_table.php
+++ b/database/migrations/2025_06_17_165107_create_personal_access_tokens_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('personal_access_tokens', function (Blueprint $table) {
+            $table->id();
+            $table->morphs('tokenable');
+            $table->string('name');
+            $table->string('token', 64)->unique();
+            $table->text('abilities')->nullable();
+            $table->timestamp('last_used_at')->nullable();
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('personal_access_tokens');
+    }
+};

--- a/database/seeders/AccountSeeder.php
+++ b/database/seeders/AccountSeeder.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class AccountSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        //
+    }
+}

--- a/database/seeders/CategorySeeder.php
+++ b/database/seeders/CategorySeeder.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class CategorySeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        //
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -15,9 +15,9 @@ class DatabaseSeeder extends Seeder
     {
         // User::factory(10)->create();
 
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
+        $this->call([
+            CategorySeeder::class,
+            AccountSeeder::class,
         ]);
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,10 +1,26 @@
 <?php
 
+use App\Http\Controllers\AuthController;
 use App\Http\Controllers\API\{AccountController, CategoryController, TransactionController};
 use Illuminate\Support\Facades\Route;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Cache\RateLimiting\Limit;
 
-Route::middleware('auth:sanctum')->group(function () {
+// Definição do rate limiter
+RateLimiter::for('api', function (Request $request) {
+    return Limit::perMinute(60)->by($request->user()?->id ?: $request->ip());
+});
+
+// Rotas públicas
+Route::post('/register', [AuthController::class, 'register']);
+Route::post('/login', [AuthController::class, 'login']);
+
+// Rotas protegidas com autenticação e rate limit
+Route::middleware(['auth:sanctum', 'throttle:api'])->group(function () {
     Route::apiResource('accounts', AccountController::class);
     Route::apiResource('categories', CategoryController::class);
     Route::apiResource('transactions', TransactionController::class);
+
+    Route::post('/logout', [AuthController::class, 'logout']);
 });


### PR DESCRIPTION
This pull request introduces changes to implement API authentication using Laravel Sanctum, adds new database migrations and seeders, and refactors the routing and middleware configuration. The most important changes include enabling Sanctum for API token-based authentication, creating the `personal_access_tokens` table, and defining rate limiting and authentication middleware for API routes.

### Authentication and Middleware Updates:
* [`app/Models/User.php`](diffhunk://#diff-37a2d7d879a7de3f7d73b2975cd22be9f41ec10c334a0dda9ad1e869332e4ecbR9-R14): Added the `HasApiTokens` trait to the `User` model to enable API token functionality.
* [`bootstrap/app.php`](diffhunk://#diff-10bc2462d34ebc59a5d482a1faca04ce74f6df89fcc2ef8bfb17b939647ea518L6-R22): Refactored middleware configuration to include aliases for authentication (`auth:sanctum`) and removed direct middleware references from the API group.

### Database Changes:
* [`database/migrations/2025_06_17_165107_create_personal_access_tokens_table.php`](diffhunk://#diff-9847b5a59d9e68f6426ab6a5c7ccda33f60d1d7f3b4a71ade798aaf058acc356R1-R33): Created a migration to define the `personal_access_tokens` table for storing API tokens.
* [`database/seeders/DatabaseSeeder.php`](diffhunk://#diff-ccad8b4ee6013765c2bc672aa0515f8e99e42949c914cce01e0cb2b4e882775dL18-R20): Updated the main database seeder to call new seeders for `CategorySeeder` and `AccountSeeder`.

### Routing Enhancements:
* [`routes/api.php`](diffhunk://#diff-0e4323e6a03c91c9c8dc88afef15fdad09636468c0ac3550f497618372788b6dR3-R25): Added rate limiting for API requests, public routes for user registration and login, and protected routes for logout and resource management with authentication and throttling.